### PR TITLE
Allow Dart 3.8 / Flutter 3.32

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ _author: David PHAM-VAN <dev.nfet.net@gmail.com>
 version: 2.1.0
 
 environment:
-  sdk: ">=3.9.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
   args: ^2.0.0


### PR DESCRIPTION
This makes the latest package version work with flutter 3.32. Without this change, I can't build this package together with some of the Riverpod 3 packages on Flutter 3.32. The latest package version works without an issue on this flutter version.